### PR TITLE
Extrai número de atrasos, recebendo como parâmetro o ano de referência

### DIFF
--- a/delay
+++ b/delay
@@ -6,18 +6,18 @@ if [ $num1 -eq 2006 ]
 then
 echo "O número de voos que chegaram atrasados em 2006:"
 csvcut -c 15 2006 | csvgrep --c 1 --regex "^[:1-9:]" > 2006_teste
-wc -l 2006_teste
+sed '1d' 2006_teste | wc -l 
 echo "O número de voos que saíram atrasados em 2006:"
 csvcut -c 16 2006 | csvgrep --c 1 --regex "^[:1-9:]" > 2006_teste
-wc -l 2006_teste
+sed '1d' 2006_teste | wc -l 
 elif [ $num1 -eq 2007 ]
 then
 echo "O número de voos que chegaram atrasados em 2007:"
 csvcut -c 15 2007 | csvgrep --c 1 --regex "^[:1-9:]" > 2007_teste
-wc -l 2007_teste
+sed '1d' 2007_teste | wc -l 
 echo "O número de voos que saíram atrasados em 2007:"
 csvcut -c 16 2007 | csvgrep --c 1 --regex "^[:1-9:]" > 2007_teste
-wc -l 2007_teste
+sed '1d' 2007_teste | wc -l 
 else
 echo "O ano digitado é inválido!"
 fi

--- a/delay
+++ b/delay
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+echo "Digite o ano (2006 ou 2007)"
+  read num1
+if [ $num1 -eq 2006 ]
+then
+echo "O número de voos que chegaram atrasados em 2006:"
+csvcut -c 15 2006 | csvgrep --c 1 --regex "^[:1-9:]" > 2006_teste
+wc -l 2006_teste
+echo "O número de voos que saíram atrasados em 2006:"
+csvcut -c 16 2006 | csvgrep --c 1 --regex "^[:1-9:]" > 2006_teste
+wc -l 2006_teste
+elif [ $num1 -eq 2007 ]
+then
+echo "O número de voos que chegaram atrasados em 2007:"
+csvcut -c 15 2007 | csvgrep --c 1 --regex "^[:1-9:]" > 2007_teste
+wc -l 2007_teste
+echo "O número de voos que saíram atrasados em 2007:"
+csvcut -c 16 2007 | csvgrep --c 1 --regex "^[:1-9:]" > 2007_teste
+wc -l 2007_teste
+else
+echo "O ano digitado é inválido!"
+fi


### PR DESCRIPTION
O script é capaz de quantificar os atrasos tanto em chegada, quanto em saída (separadamente), recebendo como parâmetro o ano de referência (2006 ou 2007).